### PR TITLE
Feature: only color tag name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-	"name": "color-the-tag-name",
-	"displayName": "Color the tag name（タグに色つけ太郎）",
+  "name": "color-the-tag-name",
+  "displayName": "Color the tag name（タグに色つけ太郎）",
   "description": "This extension will make your html tags colorful, just like my hair. Vue, React Components are also OK.",
   "version": "0.24.0",
-	"publisher": "jzmstrjp",
+  "publisher": "jzmstrjp",
   "license": "MIT",
   "homepage": "https://github.com/jzmstrjp/vscode-color-the-tag-name/blob/main/README.md",
   "bugs": {
@@ -19,13 +19,25 @@
   "icon": "img/icon.png",
   "categories": [
     "Other",
-		"Themes"
+    "Themes"
   ],
   "activationEvents": [
-		"*"
-	],
+    "*"
+  ],
   "main": "./dist/extension.js",
-  "contributes": {},
+  "contributes": {
+    "configuration": {
+      "title": "Color the tag name",
+      "type": "object",
+      "properties": {
+        "colorTheTagName.onlyColorTagName": {
+          "type": "boolean",
+          "default": false,
+          "description": "Set to true to only color the name of the tag"
+        }
+      }
+    }
+  },
   "scripts": {
     "vscode:prepublish": "npm run package",
     "compile": "webpack",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,7 +34,7 @@ const decorateInner = (tagInfo: TagInfo, editor: vscode.TextEditor, src: string)
         regex = new RegExp(
             `${commentSetting.startRegExp || commentSetting.start}|${
                 commentSetting.endRegExp || commentSetting.end
-            }|<(\/?)${tagInfo.tagName}(?=\\s|>|$)`,
+            }|<(\/?)${tagInfo.tagName}(?=\\s|\\/>|>|$)`,
             'gm'
         );
     } else {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -115,35 +115,10 @@ const decorate = () => {
     if (editor.document.fileName.endsWith(".ts")) {
         return;
     }
-    
     const src = editor.document.getText();
-
-    // First, identify comment regions
-    const commentSetting: CommentSetting =
-        commentSettingMap[editor.document.languageId] ||
-        commentSettingMap.default;
-    const commentRegex = new RegExp(
-        `(${commentSetting.startRegExp || commentSetting.start})(.*?)(${
-            commentSetting.endRegExp || commentSetting.end
-        })`,
-        'gs'
-    );
-
-    // Create a copy of the source with comments removed for tag extraction
-    let cleanSrc = src.replace(commentRegex, '');
-
-    // Now extract tags from the clean source
-    const matches =
-        cleanSrc.match(
-            /<(?:\/|)([a-zA-Z][a-zA-Z0-9.-]*)(?:$|(?:| (?:.*?)[^-?%$])(?<!=)>)/gm
-        ) || [];
-
-    const tagNameLikeWords = matches.map((word) =>
-        word.replace(/[</>]|(?: .*$)/g, '')
-    );
+    const matches = src.match(/<(?:\/|)([a-zA-Z][a-zA-Z0-9.-]*)(?:$|(?:| (?:.*?)[^-?%$])(?<!=)>)/gm) || [];
+    const tagNameLikeWords = matches.map((word) => word.replace(/[</>]|(?: .*$)/g, ''));
     const uniqueTagNames = [...new Set(tagNameLikeWords)];
-
-
     const themeType = isLightTheme() ? 'light' : 'dark'; // テーマの種類を取得
     uniqueTagNames.forEach((tagName) => {
         // まだないタグ名の分だけ追加。

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -54,38 +54,51 @@ const decorateInner = (tagInfo: TagInfo, editor: vscode.TextEditor, src: string)
         })
     };
     while (match = regex.exec(src)) {
-        const splited = match[0].split(/[{}"]/);
-        // コメントだったら飛ばす
-        if (match[0] === commentSetting.start) {
-            // コメント開始
-            inComment = true;
-            continue;
-        }
-        if (match[0] === commentSetting.end) {
-            // コメント終了
-            inComment = false;
-            continue;
-        }
-        if (inComment === true) {
-            continue;
-        }
-        let singleLengths = 0;
-        if (splited.length > 2) {
-            splited.forEach(function (single, i) {
-                // 偶数だったら
-                if (i % 2 === 0 && match !== null && tagInfo.decChar !== undefined) {
-                    const startPos = editor.document.positionAt(match.index + singleLengths);
-                    const endPos = editor.document.positionAt(match.index + singleLengths + single.length);
-                    const range = new vscode.Range(startPos, endPos);
-                    tagInfo.decChar.chars.push(range);
-                }
-                singleLengths += single.length + 1;
-            });
-        } else {
-            const startPos = editor.document.positionAt(match.index);
-            const endPos = editor.document.positionAt(match.index + match[0].length);
+        if (onlyColorTagName) {
+            // Only color the tag name itself, not the brackets
+            const slashLength = match[1] ? 1 : 0; // Length of the slash if present
+            const startPos = editor.document.positionAt(
+                match.index + 1 + slashLength
+            ); // +1 for '<'
+            const endPos = editor.document.positionAt(
+                match.index + 1 + slashLength + tagInfo.tagName.length
+            );
             const range = new vscode.Range(startPos, endPos);
             tagInfo.decChar.chars.push(range);
+        } else {
+            const splited = match[0].split(/[{}"]/);
+            // コメントだったら飛ばす
+            if (match[0] === commentSetting.start) {
+                // コメント開始
+                inComment = true;
+                continue;
+            }
+            if (match[0] === commentSetting.end) {
+                // コメント終了
+                inComment = false;
+                continue;
+            }
+            if (inComment === true) {
+                continue;
+            }
+            let singleLengths = 0;
+            if (splited.length > 2) {
+                splited.forEach(function (single, i) {
+                    // 偶数だったら
+                    if (i % 2 === 0 && match !== null && tagInfo.decChar !== undefined) {
+                        const startPos = editor.document.positionAt(match.index + singleLengths);
+                        const endPos = editor.document.positionAt(match.index + singleLengths + single.length);
+                        const range = new vscode.Range(startPos, endPos);
+                        tagInfo.decChar.chars.push(range);
+                    }
+                    singleLengths += single.length + 1;
+                });
+            } else {
+                const startPos = editor.document.positionAt(match.index);
+                const endPos = editor.document.positionAt(match.index + match[0].length);
+                const range = new vscode.Range(startPos, endPos);
+                tagInfo.decChar.chars.push(range);
+            }
         }
     }
     editor.setDecorations(tagInfo.decChar.decorator, tagInfo.decChar.chars);


### PR DESCRIPTION
Hi! Thanks for the helpful extension. I added a config option to only color the tag name itself because I found it useful for developing with Vue. This way you can use the custom colors for the tag names while keeping the default syntax highlighting for the other parameters.