### PR TITLE
Feature: Improved Vue support

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -88,15 +88,20 @@ const selectSearchText = (src: string, languageId: string): string => {
             const firstTemplateMatch = src.match(/<template>/);
             const lastTemplateEndMatch = src.match(/<\/template>[^]*$/);
 
-            if (firstTemplateMatch && lastTemplateEndMatch) {
-                const startIndex = firstTemplateMatch.index + '<template>'.length;
-                const endIndex = lastTemplateEndMatch.index;
+            if (
+              firstTemplateMatch &&
+              lastTemplateEndMatch &&
+              firstTemplateMatch.index &&
+              lastTemplateEndMatch.index
+            ) {
+              const startIndex = firstTemplateMatch.index + '<template>'.length;
+              const endIndex = lastTemplateEndMatch.index;
 
-                // Extract everything between the first opening and last closing template tags
-                return src.substring(startIndex, endIndex);
+              // Extract everything between the first opening and last closing template tags
+              return src.substring(startIndex, endIndex);
             } else {
-                // No template or incomplete template, nothing to decorate
-                return '';
+              // No template or incomplete template, nothing to decorate
+              return '';
             }
         }
         default: {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -83,12 +83,19 @@ const selectSearchText = (src: string, languageId: string): string => {
     switch (languageId) {
         case 'vue': {
             // Vue support, currently does not consider jsx/tsx in <script> tags
-            // Look for <template> tags and extract the content inside them
-            const templateMatch = src.match(/<template>([\s\S]*?)<\/template>/);
-            if (templateMatch) {
-                return templateMatch[1];
+            // Extract from first <template> to last </template>
+            // Use a two-step approach to find the correct content
+            const firstTemplateMatch = src.match(/<template>/);
+            const lastTemplateEndMatch = src.match(/<\/template>[^]*$/);
+
+            if (firstTemplateMatch && lastTemplateEndMatch) {
+                const startIndex = firstTemplateMatch.index + '<template>'.length;
+                const endIndex = lastTemplateEndMatch.index;
+
+                // Extract everything between the first opening and last closing template tags
+                return src.substring(startIndex, endIndex);
             } else {
-                // No template, nothing to decorate
+                // No template or incomplete template, nothing to decorate
                 return '';
             }
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -88,7 +88,11 @@ const selectSearchText = (src: string, languageId: string): [string, number] => 
                 /<template>([^]*)<\/template>/s
             );
 
-            if (rootTemplateMatch && rootTemplateMatch[0]) {
+            if (
+                rootTemplateMatch &&
+                rootTemplateMatch[0] &&
+                rootTemplateMatch.index
+            ) {
                 return [rootTemplateMatch[0], rootTemplateMatch.index];
             } else {
                 // No template or incomplete template, nothing to decorate

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -91,7 +91,7 @@ const selectSearchText = (src: string, languageId: string): [string, number] => 
             if (
                 rootTemplateMatch &&
                 rootTemplateMatch[0] &&
-                rootTemplateMatch.index
+                rootTemplateMatch.index !== undefined
             ) {
                 return [rootTemplateMatch[0], rootTemplateMatch.index];
             } else {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -84,24 +84,15 @@ const selectSearchText = (src: string, languageId: string): string => {
         case 'vue': {
             // Vue support, currently does not consider jsx/tsx in <script> tags
             // Extract from first <template> to last </template>
-            // Use a two-step approach to find the correct content
-            const firstTemplateMatch = src.match(/<template>/);
-            const lastTemplateEndMatch = src.match(/<\/template>[^]*$/);
+            const rootTemplateMatch = src.match(
+                /<template>([^]*)<\/template>/s
+            );
 
-            if (
-              firstTemplateMatch &&
-              lastTemplateEndMatch &&
-              firstTemplateMatch.index &&
-              lastTemplateEndMatch.index
-            ) {
-              const startIndex = firstTemplateMatch.index + '<template>'.length;
-              const endIndex = lastTemplateEndMatch.index;
-
-              // Extract everything between the first opening and last closing template tags
-              return src.substring(startIndex, endIndex);
+            if (rootTemplateMatch && rootTemplateMatch[0]) {
+                return rootTemplateMatch[0];
             } else {
-              // No template or incomplete template, nothing to decorate
-              return '';
+                // No template or incomplete template, nothing to decorate
+                return '';
             }
         }
         default: {


### PR DESCRIPTION
Added logic to only check for tags within the outermost `<template></template>` when decorating `'vue'` language files. It's in a helper function so other languages can be added if needed. It doesn't consider any JSX/TSX in the `<script>` tags, but I think this trade off is okay for now since it won't highlight types in Vue files using TypeScript anymore and it is a bit tricky to distinguish the tags from the types in files with both.